### PR TITLE
CIVDT-322: Added the create case endpoint

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -30,5 +30,7 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
   val graphiteHost: String     = config.get[String]("microservice.metrics.graphite.host")
 
   lazy val sub09: String = servicesConfig.baseUrl("import-voluntary-disclosure-stub") // change from stub to sub09
+  lazy val eisBaseUrl: String = servicesConfig.baseUrl("eis")
+  lazy val createCaseToken: String = config.get[String]("microservice.services.eis.tokens.create")
 
 }

--- a/app/connectors/EisConnector.scala
+++ b/app/connectors/EisConnector.scala
@@ -32,14 +32,14 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class EisConnector @Inject()(val http: HttpClient,
+class EisConnector @Inject()(http: HttpClient,
                              implicit val appConfig: AppConfig) {
 
   private val httpDateFormat = DateTimeFormatter
     .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH)
     .withZone(ZoneId.of("GMT"))
 
-  private[connectors] val createCaseUrl = s"${appConfig.eisBaseUrl}/cpr/caserequest/c18/create/v1"
+  private[connectors] lazy val createCaseUrl = s"${appConfig.eisBaseUrl}/cpr/caserequest/c18/create/v1"
 
   private[connectors] def eisHeaderCarrier()(implicit hc: HeaderCarrier): HeaderCarrier = hc
     .copy(authorization = Some(Authorization(s"Bearer ${appConfig.createCaseToken}")))

--- a/app/connectors/EisConnector.scala
+++ b/app/connectors/EisConnector.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import connectors.httpParsers.CreateCaseHttpParser.CreateCaseHttpReads
+import connectors.httpParsers.ResponseHttpParser.ExternalResponse
+import models.CaseDetails
+import models.requests.CreateCaseRequest
+import models.responses.CreateCaseResponse
+import uk.gov.hmrc.http.logging.Authorization
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import java.time.format.DateTimeFormatter
+import java.time.{ZoneId, ZonedDateTime}
+import java.util.{Locale, UUID}
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class EisConnector @Inject()(val http: HttpClient,
+                             implicit val appConfig: AppConfig) {
+
+  private val httpDateFormat = DateTimeFormatter
+    .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH)
+    .withZone(ZoneId.of("GMT"))
+
+  private[connectors] val createCaseUrl = s"${appConfig.eisBaseUrl}/cpr/caserequest/c18/create/v1"
+
+  private[connectors] def eisHeaderCarrier()(implicit hc: HeaderCarrier): HeaderCarrier = hc
+    .copy(authorization = Some(Authorization(s"Bearer ${appConfig.createCaseToken}")))
+    .withExtraHeaders(
+      "x-correlation-id" -> UUID.randomUUID().toString,
+      "CustomProcessesHost" -> "Digital",
+      "date" -> httpDateFormat.format(ZonedDateTime.now),
+      "accept" -> "application/json"
+    )
+
+  def createCase(caseDetails: CaseDetails)
+                (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[ExternalResponse[CreateCaseResponse]] = {
+    val request = CreateCaseRequest(caseDetails)
+    http.POST(createCaseUrl, request)(implicitly, CreateCaseHttpReads, eisHeaderCarrier(), implicitly)
+  }
+
+}

--- a/app/connectors/httpParsers/CreateCaseHttpParser.scala
+++ b/app/connectors/httpParsers/CreateCaseHttpParser.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import connectors.httpParsers.ResponseHttpParser.ExternalResponse
+import models.ErrorModel
+import models.responses.CreateCaseResponse
+import play.api.Logging
+import play.api.http.Status
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+
+object CreateCaseHttpParser {
+
+  implicit object CreateCaseHttpReads extends HttpReads[ExternalResponse[CreateCaseResponse]] with Logging {
+
+    override def read(method: String, url: String, response: HttpResponse): ExternalResponse[CreateCaseResponse] = {
+
+      val correlationId = response.header("x-correlation-id").getOrElse("UNKNOWN")
+      val apiFriendlyName = "IVD - Create Case"
+
+      response.status match {
+        case Status.OK =>
+          response.json.validate[CreateCaseResponse].fold(
+            invalid => {
+              val errorMessage =
+                s"""API: $apiFriendlyName
+                   |Correlation ID: $correlationId
+                   |Problem: Failed to parse JSON for a successful response.
+                   |Details: $invalid""".stripMargin
+
+              logger.error(errorMessage)
+              Left(ErrorModel(Status.OK, "INVALID JSON"))
+            },
+            data => Right(data)
+          )
+        case status =>
+          val errorMessage =
+            s"""API: $apiFriendlyName
+               |Problem: Non-success response returned when attempting to create a case
+               |Correlation ID: $correlationId
+               |Status: $status
+               |Body: ${response.body}""".stripMargin
+          logger.error(errorMessage)
+          Left(ErrorModel(status, "Non-success response"))
+      }
+
+    }
+  }
+
+}

--- a/app/controllers/CreateCaseController.scala
+++ b/app/controllers/CreateCaseController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import models.CaseDetails
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, ControllerComponents}
+import services.CreateCaseService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Singleton()
+class CreateCaseController @Inject()(cc: ControllerComponents,
+                                     service: CreateCaseService)
+  extends BackendController(cc) {
+
+  def onSubmit(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    val caseDetails = request.body.as[CaseDetails]
+    service.createCase(caseDetails).map {
+      case Right(response) => Ok(Json.toJson(response))
+      case Left(_) => InternalServerError(Json.obj())
+    }
+
+  }
+
+}

--- a/app/models/CaseDetails.scala
+++ b/app/models/CaseDetails.scala
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package connectors.httpParsers
+package models
 
-import models.ErrorModel
+import play.api.libs.json.{Json, OFormat}
 
-object ResponseHttpParser {
-  type HttpGetResult[T] = Either[ErrorModel, T]
-  type ExternalResponse[T] = Either[ErrorModel, T]
+case class CaseDetails(value: Option[String])
+
+object CaseDetails {
+  implicit val formats: OFormat[CaseDetails] = Json.format[CaseDetails]
 }

--- a/app/models/requests/CreateCaseRequest.scala
+++ b/app/models/requests/CreateCaseRequest.scala
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package connectors.httpParsers
+package models.requests
 
-import models.ErrorModel
+import models.CaseDetails
+import play.api.libs.json.{Json, Writes}
 
-object ResponseHttpParser {
-  type HttpGetResult[T] = Either[ErrorModel, T]
-  type ExternalResponse[T] = Either[ErrorModel, T]
+case class CreateCaseRequest(content: CaseDetails)
+
+object CreateCaseRequest {
+  implicit val writes: Writes[CreateCaseRequest] = Json.writes[CreateCaseRequest]
 }

--- a/app/models/responses/CreateCaseResponse.scala
+++ b/app/models/responses/CreateCaseResponse.scala
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-package connectors.httpParsers
+package models.responses
 
-import models.ErrorModel
+import play.api.libs.json._
 
-object ResponseHttpParser {
-  type HttpGetResult[T] = Either[ErrorModel, T]
-  type ExternalResponse[T] = Either[ErrorModel, T]
+case class CreateCaseResponse(id: String)
+
+object CreateCaseResponse {
+  implicit val reads: Reads[CreateCaseResponse] = (json: JsValue) => {
+    (json \ "CaseID").validate[String].fold(
+      error => JsError(error),
+      caseId => JsSuccess(CreateCaseResponse(caseId))
+    )
+  }
 }

--- a/app/models/responses/CreateCaseResponse.scala
+++ b/app/models/responses/CreateCaseResponse.scala
@@ -21,10 +21,14 @@ import play.api.libs.json._
 case class CreateCaseResponse(id: String)
 
 object CreateCaseResponse {
-  implicit val reads: Reads[CreateCaseResponse] = (json: JsValue) => {
+  val reads: Reads[CreateCaseResponse] = (json: JsValue) => {
     (json \ "CaseID").validate[String].fold(
       error => JsError(error),
       caseId => JsSuccess(CreateCaseResponse(caseId))
     )
   }
+
+  val writes: Writes[CreateCaseResponse] = Json.writes[CreateCaseResponse]
+
+  implicit val formats: Format[CreateCaseResponse] = Format(reads, writes)
 }

--- a/app/services/CreateCaseService.scala
+++ b/app/services/CreateCaseService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.EisConnector
+import models.responses.CreateCaseResponse
+import models.{CaseDetails, ErrorModel}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CreateCaseService @Inject()(connector: EisConnector) {
+
+  def createCase(caseDetails: CaseDetails)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorModel, CreateCaseResponse]] = {
+    connector.createCase(caseDetails)
+  }
+
+}

--- a/app/services/ImporterAddressService.scala
+++ b/app/services/ImporterAddressService.scala
@@ -16,19 +16,15 @@
 
 package services
 
-import config.AppConfig
 import connectors.ImporterAddressConnector
-import javax.inject.{Inject, Singleton}
 import models.{ErrorModel, TraderAddress}
-import play.api.i18n.MessagesApi
 import uk.gov.hmrc.http.HeaderCarrier
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ImporterAddressService @Inject()(importerAddressConnector: ImporterAddressConnector,
-                                       implicit val messagesApi: MessagesApi,
-                                       implicit val appConfig: AppConfig) {
+class ImporterAddressService @Inject()(importerAddressConnector: ImporterAddressConnector) {
 
   def retrieveAddress(id: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorModel, TraderAddress]] = {
     importerAddressConnector.getAddress(id)

--- a/conf/api.routes
+++ b/conf/api.routes
@@ -1,1 +1,2 @@
 GET        /address        controllers.ImporterAddressController.onLoad(id: String ?= "")
+POST       /case           controllers.CreateCaseController.onSubmit()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,6 +131,15 @@ microservice {
       port = 8500
     }
 
+    eis {
+      protocol = http
+      host = localhost
+      port = 7952
+      tokens {
+        create = "TBC"
+      }
+    }
+
     import-voluntary-disclosure-stub {
       host = localhost
       port = 7952

--- a/test/base/ServiceSpecBase.scala
+++ b/test/base/ServiceSpecBase.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.http.HeaderCarrier
+
+trait ServiceSpecBase extends AnyWordSpec {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -22,10 +22,8 @@ import org.scalatest.TryValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents}
 import play.api.test.CSRFTokenHelper.CSRFRequest
-import play.api.test.Helpers.baseApplicationBuilder.injector
 import play.api.test.{FakeRequest, Helpers}
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
@@ -51,8 +49,6 @@ trait SpecBase extends AnyWordSpec
   val appConfig = new AppConfig(configuration, serviceConfig)
 
   val controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
-
-  implicit lazy val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/connectors/EisConnectorSpec.scala
+++ b/test/connectors/EisConnectorSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import connectors.httpParsers.ResponseHttpParser.ExternalResponse
+import mocks.MockHttp
+import models.CaseDetails
+import models.requests.CreateCaseRequest
+import models.responses.CreateCaseResponse
+import org.scalatest.matchers.should.Matchers._
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class EisConnectorSpec extends SpecBase {
+
+  trait Test extends MockHttp {
+    lazy val target = new EisConnector(mockHttp, appConfig)
+  }
+
+  val expectedCreateCaseUrl = "http://localhost:7952/cpr/caserequest/c18/create/v1"
+
+  "createCaseUrl" should {
+
+    "return the correct URL" in new Test {
+      target.createCaseUrl shouldBe expectedCreateCaseUrl
+    }
+
+  }
+
+  "eisHeaderCarrier" should {
+
+    "generate the correct CustomProcessesHost header required for EIS" in new Test {
+      private val headerCarrier = target.eisHeaderCarrier()
+      headerCarrier.extraHeaders should contain ("CustomProcessesHost" -> "Digital")
+    }
+
+    "generate the correct Accept header required for EIS" in new Test {
+      private val headerCarrier = target.eisHeaderCarrier()
+      headerCarrier.extraHeaders should contain ("accept" -> "application/json")
+    }
+
+    "generate the correct Correlation ID header required for EIS" in new Test {
+      private val headerCarrier = target.eisHeaderCarrier()
+      headerCarrier.extraHeaders.toMap.keys should contain ("x-correlation-id")
+    }
+
+    "generate the correct Date header required for EIS" in new Test {
+      private val headerCarrier = target.eisHeaderCarrier()
+      headerCarrier.extraHeaders.toMap.keys should contain ("date")
+    }
+
+  }
+
+  "createCase" when {
+
+    "a success response is returned from EIS" should {
+
+      "return a CreateCaseResponse" in new Test {
+        val response = Right(CreateCaseResponse("some case ID"))
+        MockedHttp.post[CreateCaseRequest, ExternalResponse[CreateCaseResponse]](expectedCreateCaseUrl, response)
+
+        await(target.createCase(CaseDetails(Some("blah")))) shouldBe response
+      }
+
+    }
+
+  }
+}

--- a/test/connectors/httpParsers/CreateCaseHttpParserSpec.scala
+++ b/test/connectors/httpParsers/CreateCaseHttpParserSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.httpParsers
+
+import base.SpecBase
+import connectors.httpParsers.CreateCaseHttpParser.CreateCaseHttpReads
+import models.ErrorModel
+import models.responses.CreateCaseResponse
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.HttpResponse
+
+import java.time.Instant
+import java.util.UUID
+
+class CreateCaseHttpParserSpec extends SpecBase {
+
+  "Parsing a 200 (OK) response" when {
+
+    "the response is valid" should {
+
+      val headers: Map[String, Seq[String]] = Map("x-correlation-id" -> Seq(UUID.randomUUID().toString))
+      val body: JsObject = Json.obj(
+        "CaseID" -> "C18-101",
+        "ProcessingDate" -> Instant.now().toString,
+        "Status" -> "Success",
+        "StatusText" -> "Case created successfully"
+      )
+
+      val response = HttpResponse(Status.OK, body, headers)
+
+      "return the Case ID" in {
+        CreateCaseHttpReads.read("", "", response) mustBe Right(CreateCaseResponse("C18-101"))
+      }
+
+    }
+
+    "the response does not contain a case ID" should {
+
+      val headers: Map[String, Seq[String]] = Map("x-correlation-id" -> Seq(UUID.randomUUID().toString))
+      val body: JsObject = Json.obj(
+        "ProcessingDate" -> Instant.now().toString,
+        "Status" -> "Success",
+        "StatusText" -> "Case created successfully"
+      )
+
+      val response = HttpResponse(Status.OK, body, headers)
+
+      "return an error" in {
+        CreateCaseHttpReads.read("", "", response) mustBe Left(ErrorModel(Status.OK, "INVALID JSON"))
+      }
+
+    }
+  }
+
+  "Parsing a non-200 response" should {
+
+    val headers: Map[String, Seq[String]] = Map("x-correlation-id" -> Seq(UUID.randomUUID().toString))
+    val body: JsObject = Json.obj()
+    val response = HttpResponse(Status.BAD_REQUEST, body, headers)
+
+    "return an error" in {
+      CreateCaseHttpReads.read("", "", response) mustBe Left(ErrorModel(Status.BAD_REQUEST, "Non-success response"))
+    }
+
+  }
+
+}

--- a/test/controllers/CreateCaseControllerSpec.scala
+++ b/test/controllers/CreateCaseControllerSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import mocks.services.MockCreateCaseService
+import models.responses.CreateCaseResponse
+import models.{CaseDetails, ErrorModel}
+import org.scalatest.matchers.should.Matchers
+import play.api.http.{ContentTypes, Status}
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsJson, contentType, defaultAwaitTimeout, status}
+import play.mvc.Http.HeaderNames
+
+class CreateCaseControllerSpec extends SpecBase with Matchers {
+
+  trait Test extends MockCreateCaseService {
+    lazy val target = new CreateCaseController(controllerComponents, mockCreateCaseService)
+    val validRequest: FakeRequest[JsObject] = FakeRequest(controllers.routes.CreateCaseController.onSubmit())
+      .withHeaders(
+        HeaderNames.CONTENT_TYPE -> ContentTypes.JSON,
+        HeaderNames.ACCEPT -> ContentTypes.JSON
+      )
+      .withBody(Json.obj())
+
+  }
+
+  "onSubmit" when {
+    "case create in downstream services" should {
+
+      val successResponse = Right(CreateCaseResponse("some id"))
+
+      "return 200 (OK) response" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), successResponse)
+        private val result = target.onSubmit()(validRequest)
+        status(result) shouldBe Status.OK
+      }
+
+      "return JSON payload" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), successResponse)
+        private val result = target.onSubmit()(validRequest)
+        contentType(result) shouldBe Some(ContentTypes.JSON)
+      }
+
+
+      "return the correct JSON" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), successResponse)
+        private val result = target.onSubmit()(validRequest)
+        contentAsJson(result) shouldBe Json.obj("id" -> "some id")
+      }
+
+    }
+
+    "case creation fails in downstream services" should {
+
+      val failedResponse = Left(ErrorModel(Status.BAD_REQUEST, "some error"))
+
+      "return 500 (INTERNAL SERVER ERROR) response" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), failedResponse)
+        private val result = target.onSubmit()(validRequest)
+        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+      }
+
+      "return JSON payload" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), failedResponse)
+        private val result = target.onSubmit()(validRequest)
+        contentType(result) shouldBe Some(ContentTypes.JSON)
+      }
+
+
+      "return the correct JSON" in new Test {
+        MockedCreateCaseService.createCase(CaseDetails(None), failedResponse)
+        private val result = target.onSubmit()(validRequest)
+        contentAsJson(result) shouldBe Json.obj()
+      }
+
+    }
+  }
+
+}

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -18,6 +18,7 @@ package mocks
 
 import base.SpecBase
 import org.scalamock.scalatest.MockFactory
+import play.api.libs.json.Writes
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -26,6 +27,13 @@ trait MockHttp extends SpecBase with MockFactory {
 
   val mockHttp: HttpClient = mock[HttpClient]
 
+  object MockedHttp {
+    def post[I,O](url: String, response: O): Any = {
+      (mockHttp.POST[I,O](_: String, _: I, _: Seq[(String, String)])(_: Writes[I], _: HttpReads[O], _: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *, *, *, *, *, *)
+        .returns(Future.successful(response))
+    }
+  }
   def setupMockHttpGet[T](url: String)(response: T): Unit =
     (mockHttp.GET[T](_: String)(_: HttpReads[T], _: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)

--- a/test/mocks/connectors/MockEisConnector.scala
+++ b/test/mocks/connectors/MockEisConnector.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.EisConnector
+import connectors.httpParsers.ResponseHttpParser.ExternalResponse
+import models.CaseDetails
+import models.responses.CreateCaseResponse
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockEisConnector extends MockFactory {
+
+  val mockEisConnector: EisConnector = mock[EisConnector]
+
+  object MockedEisConnector {
+
+    def createCase(caseDetails: CaseDetails,
+                   response: ExternalResponse[CreateCaseResponse]): CallHandler[Future[ExternalResponse[CreateCaseResponse]]] = {
+      (mockEisConnector.createCase(_: CaseDetails)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(caseDetails, *, *)
+        .returns(Future.successful(response))
+    }
+
+  }
+
+}

--- a/test/mocks/services/MockCreateCaseService.scala
+++ b/test/mocks/services/MockCreateCaseService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.services
+
+import connectors.httpParsers.ResponseHttpParser.ExternalResponse
+import models.CaseDetails
+import models.responses.CreateCaseResponse
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import services.CreateCaseService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockCreateCaseService extends MockFactory {
+
+  val mockCreateCaseService: CreateCaseService = mock[CreateCaseService]
+
+  object MockedCreateCaseService {
+
+    def createCase(caseDetails: CaseDetails,
+                   response: ExternalResponse[CreateCaseResponse]): CallHandler[Future[ExternalResponse[CreateCaseResponse]]] = {
+      (mockCreateCaseService.createCase(_: CaseDetails)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(caseDetails, *, *)
+        .returns(Future.successful(response))
+    }
+
+  }
+
+}

--- a/test/services/CreateCaseServiceSpec.scala
+++ b/test/services/CreateCaseServiceSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.ServiceSpecBase
+import mocks.connectors.MockEisConnector
+import models.CaseDetails
+import models.responses.CreateCaseResponse
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class CreateCaseServiceSpec extends ServiceSpecBase with MockEisConnector {
+
+  "createCase" should {
+
+    "return whatever the connector returns" in {
+      val caseDetails = CaseDetails(None)
+      val expectedResponse = Right(CreateCaseResponse("some id"))
+      MockedEisConnector.createCase(caseDetails, expectedResponse)
+      val service = new CreateCaseService(mockEisConnector)
+      await(service.createCase(caseDetails)) mustBe expectedResponse
+    }
+  }
+}

--- a/test/services/ImporterAddressServiceSpec.scala
+++ b/test/services/ImporterAddressServiceSpec.scala
@@ -29,7 +29,7 @@ class ImporterAddressServiceSpec extends SpecBase with MockImporterAddressConnec
 
   def setup(traderAddressResponse: TraderAddressResponse): ImporterAddressService = {
     setupMockGetAddress(traderAddressResponse)
-    new ImporterAddressService(mockAddressLookupConnector, messagesApi, appConfig)
+    new ImporterAddressService(mockAddressLookupConnector)
   }
 
   "connector call is successful" should {


### PR DESCRIPTION
Currently accepts any valid JSON payload and will return a success payload. Updated `README.md` and request validation to follow.